### PR TITLE
refactor: improve Makefile structure and add init, plan, apply targets

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,17 +34,21 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
 
       - name: Find Terraform project directories
         id: find-dirs
         run: |
+          set -euo pipefail
           # Find subdirectories in terraform/ except modules/
-          find terraform -mindepth 1 -maxdepth 1 -type d ! -name modules > dirs.txt
+          find terraform -mindepth 1 -maxdepth 1 -type d ! -name modules -print0 > dirs.txt
           cat dirs.txt
 
       - name: Run Terraform Plan or Apply
         run: |
-          while read d; do
+          set -euo pipefail
+          while IFS= read -r -d '' d; do
             cd "$d"
             echo "::group::Running in $d"
             terraform init -input=false

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,43 @@
 # Makefile for Terraform formatting and linting
 
-TERRAFORM_DIRS := $(shell find terraform -type d)
+.SHELLFLAGS := -e -c
 
-.PHONY: format lint all
+TERRAFORM_DIRS := $(shell find terraform -type d \( -name .terraform \) -prune -o -type d -print)
+TERRAFORM_PROJ_DIRS := $(shell find terraform -maxdepth 1 -mindepth 1 -type d ! -name modules ! -name .terraform)
 
-all: format lint
+.PHONY: fmt lint init plan apply all
+
+all: fmt lint
 
 fmt:
 	@echo "Formatting Terraform files..."
-	@for dir in $(TERRAFORM_DIRS); do \
-	  terraform -chdir=$$dir fmt -recursive; \
-	done
+	@terraform fmt -recursive 
 
 lint:
 	@echo "Linting Terraform files..."
 	@for dir in $(TERRAFORM_DIRS); do \
-	  terraform -chdir=$$dir init -backend=false -input=false >/dev/null; \
-	  terraform -chdir=$$dir validate; \
+		echo "Validating Terraform in $$dir..."; \
+		terraform -chdir=$$dir init -backend=false -input=false >/dev/null; \
+		terraform -chdir=$$dir validate; \
+	done
+
+init:
+	@echo "Initializing Terraform directories..."
+	@for dir in $(TERRAFORM_DIRS); do \
+		echo "Initializing Terraform in $$dir..."; \
+		terraform -chdir=$$dir init; \
+	done
+
+plan:
+	@echo "Planning Terraform changes..."
+	@for dir in $(TERRAFORM_PROJ_DIRS); do \
+		echo "Planning Terraform in $$dir..."; \
+		terraform -chdir=$$dir plan; \
+	done
+
+apply:
+	@echo "Applying Terraform changes..."
+	@for dir in $(TERRAFORM_PROJ_DIRS); do \
+		echo "Applying Terraform in $$dir..."; \
+		terraform -chdir=$$dir apply -auto-approve; \
 	done


### PR DESCRIPTION
This pull request introduces updates to Terraform workflows and the `Makefile` to improve automation and streamline Terraform operations. Key changes include specifying the Terraform version in workflows, enhancing directory handling for Terraform commands, and adding new targets to the `Makefile` for better control over Terraform operations.

### Updates to Terraform workflows:

* [`.github/workflows/terraform.yml`](diffhunk://#diff-10eac00f40a120814e0c56ca5bf5a61c8b335acbdeb977b72207606aa3daea4dR37-R51): Specified `terraform_version` as `1.9.8` to ensure consistency across environments. Enhanced directory handling by using `-print0` and `IFS` to manage filenames with special characters. Added `set -euo pipefail` for stricter error handling in scripts.

### Improvements to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L3-R43): Refined directory discovery to exclude `.terraform` directories and added `TERRAFORM_PROJ_DIRS` for project-specific operations. Introduced new targets (`init`, `plan`, `apply`) for initializing, planning, and applying Terraform changes, improving modularity and usability. Updated `fmt` and `lint` targets to simplify and enhance Terraform file formatting and validation processes.