### PR TITLE
feat: add Amplify app module with GitHub integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ plan.out
 terraform.rc
 
 .op/
+.envrc

--- a/terraform/common/main.tf
+++ b/terraform/common/main.tf
@@ -22,10 +22,10 @@ resource "aws_route53_record" "jentz_co_mx" {
 }
 
 resource "aws_route53_record" "jentz_co_ns" {
-  name            = "jentz.co"
-  ttl             = 172800
-  type            = "NS"
-  zone_id         = aws_route53_zone.jentz_co.zone_id
+  name    = "jentz.co"
+  ttl     = 172800
+  type    = "NS"
+  zone_id = aws_route53_zone.jentz_co.zone_id
   records = [
     "ns-1473.awsdns-56.org.",
     "ns-1983.awsdns-55.co.uk.",
@@ -35,19 +35,19 @@ resource "aws_route53_record" "jentz_co_ns" {
 }
 
 resource "aws_route53_record" "jentz_co_soa" {
-  name            = "jentz.co"
-  ttl             = 900
-  type            = "SOA"
-  zone_id         = aws_route53_zone.jentz_co.zone_id
-  records         = ["ns-782.awsdns-33.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]
+  name    = "jentz.co"
+  ttl     = 900
+  type    = "SOA"
+  zone_id = aws_route53_zone.jentz_co.zone_id
+  records = ["ns-782.awsdns-33.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]
 }
 
 resource "aws_route53_record" "jentz_co_txt" {
-  name           = "jentz.co"
-  ttl            = 300
-  type           = "TXT"
-  zone_id        = aws_route53_zone.jentz_co.zone_id
-  records        = ["v=spf1 include:spf.messagingengine.com ?all"]
+  name    = "jentz.co"
+  ttl     = 300
+  type    = "TXT"
+  zone_id = aws_route53_zone.jentz_co.zone_id
+  records = ["v=spf1 include:spf.messagingengine.com ?all"]
 }
 
 resource "aws_route53_record" "jentz_co_dkim1" {

--- a/terraform/jentz.co/main.tf
+++ b/terraform/jentz.co/main.tf
@@ -2,4 +2,27 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+module "jentz_co_amplify" {
+  source = "../modules/amplify"
 
+  app_name       = "jentz-co"
+  repository_url = "https://github.com/jentz/jentz.co"
+
+  github_access_token = var.github_access_token
+
+  domain_name          = "jentz.co"
+  enable_www_subdomain = true
+  main_branch_name     = "main" # Change this if your main branch has a different name
+
+  hugo_version = "0.147.8" # Update to your Hugo version
+
+  environment_variables = {
+    # Add any environment variables your Hugo site needs
+    # HUGO_ENV = "production"
+  }
+
+  tags = {
+    Project = "Website"
+    Env     = "prod"
+  }
+}

--- a/terraform/jentz.co/main.tf
+++ b/terraform/jentz.co/main.tf
@@ -22,7 +22,7 @@ module "jentz_co_amplify" {
   }
 
   tags = {
-    Project = "Website"
+    Project = "jentz.co"
     Env     = "prod"
   }
 }

--- a/terraform/jentz.co/outputs.tf
+++ b/terraform/jentz.co/outputs.tf
@@ -1,0 +1,14 @@
+output "amplify_app_id" {
+  description = "ID of the Amplify app"
+  value       = module.jentz_co_amplify.app_id
+}
+
+output "amplify_default_domain" {
+  description = "Default domain for the Amplify app"
+  value       = module.jentz_co_amplify.app_default_domain
+}
+
+output "amplify_production_branch" {
+  description = "Production branch name"
+  value       = module.jentz_co_amplify.app_production_branch
+}

--- a/terraform/jentz.co/providers.tf
+++ b/terraform/jentz.co/providers.tf
@@ -16,5 +16,6 @@ terraform {
     key            = "jentz.co/terraform.tfstate"
     region         = "eu-west-1"
     dynamodb_table = "terraform-locks"
+    encrypt        = true
   }
 }

--- a/terraform/jentz.co/variables.tf
+++ b/terraform/jentz.co/variables.tf
@@ -1,5 +1,6 @@
 variable "github_access_token" {
-  description = "GitHub personal access token for repository access"
+  description = "GitHub personal access token for repository access, only used for bootstrapping the Amplify app, should be removed after."
+  default     = ""
   type        = string
   sensitive   = true
 }

--- a/terraform/jentz.co/variables.tf
+++ b/terraform/jentz.co/variables.tf
@@ -1,0 +1,5 @@
+variable "github_access_token" {
+  description = "GitHub personal access token for repository access"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/modules/amplify/.terraform.lock.hcl
+++ b/terraform/modules/amplify/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.99.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/terraform/modules/amplify/main.tf
+++ b/terraform/modules/amplify/main.tf
@@ -1,0 +1,69 @@
+resource "aws_amplify_app" "this" {
+  name         = var.app_name
+  repository   = var.repository_url
+  access_token = var.github_access_token
+
+  # Hugo build settings
+  build_spec = <<-EOT
+    version: 1
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - curl -L -o hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${var.hugo_version}/hugo_extended_${var.hugo_version}_Linux-64bit.tar.gz
+            - tar -xzf hugo.tar.gz
+            - chmod +x hugo
+        build:
+          commands:
+            - ./hugo --minify
+      artifacts:
+        baseDirectory: public
+        files:
+          - '**/*'
+      cache:
+        paths: []
+  EOT
+
+  # Auto build code when new commits are pushed
+  enable_auto_branch_creation = true
+  enable_branch_auto_build    = true
+
+  auto_branch_creation_patterns = var.auto_branch_creation_patterns
+
+  # Environment variables
+  environment_variables = var.environment_variables
+
+  tags = var.tags
+}
+
+# Set up the main branch
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.this.id
+  branch_name = var.main_branch_name
+
+  framework = "Hugo"
+  stage     = "PRODUCTION"
+
+  tags = var.tags
+}
+
+# Domain association
+resource "aws_amplify_domain_association" "this" {
+  app_id      = aws_amplify_app.this.id
+  domain_name = var.domain_name
+
+  # Set up the main domain (jentz.co)
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = ""
+  }
+
+  # Set up www subdomain if needed
+  dynamic "sub_domain" {
+    for_each = var.enable_www_subdomain ? [1] : []
+    content {
+      branch_name = aws_amplify_branch.main.branch_name
+      prefix      = "www"
+    }
+  }
+}

--- a/terraform/modules/amplify/main.tf
+++ b/terraform/modules/amplify/main.tf
@@ -1,7 +1,10 @@
 resource "aws_amplify_app" "this" {
-  name         = var.app_name
-  repository   = var.repository_url
-  access_token = var.github_access_token
+  name       = var.app_name
+  repository = var.repository_url
+
+  # Only include access_token when github_access_token is set
+  access_token = try(length(var.github_access_token) > 0 ? var.github_access_token : tostring({}), null)
+
 
   # Hugo build settings
   build_spec = <<-EOT
@@ -21,7 +24,8 @@ resource "aws_amplify_app" "this" {
         files:
           - '**/*'
       cache:
-        paths: []
+        paths:
+          - ./hugo
   EOT
 
   # Auto build code when new commits are pushed
@@ -66,4 +70,5 @@ resource "aws_amplify_domain_association" "this" {
       prefix      = "www"
     }
   }
+
 }

--- a/terraform/modules/amplify/outputs.tf
+++ b/terraform/modules/amplify/outputs.tf
@@ -1,0 +1,24 @@
+output "app_id" {
+  description = "ID of the Amplify app"
+  value       = aws_amplify_app.this.id
+}
+
+output "app_default_domain" {
+  description = "Default domain for the Amplify app"
+  value       = aws_amplify_app.this.default_domain
+}
+
+output "app_production_branch" {
+  description = "Production branch name"
+  value       = aws_amplify_branch.main.branch_name
+}
+
+output "app_arn" {
+  description = "ARN of the Amplify app"
+  value       = aws_amplify_app.this.arn
+}
+
+output "domain_association_id" {
+  description = "ID of the domain association"
+  value       = aws_amplify_domain_association.this.id
+}

--- a/terraform/modules/amplify/providers.tf
+++ b/terraform/modules/amplify/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/amplify/variables.tf
+++ b/terraform/modules/amplify/variables.tf
@@ -1,0 +1,59 @@
+variable "app_name" {
+  description = "Name of the Amplify app"
+  type        = string
+}
+
+variable "repository_url" {
+  description = "URL of the GitHub repository"
+  type        = string
+}
+
+variable "github_access_token" {
+  description = "GitHub personal access token for repository access"
+  type        = string
+  sensitive   = true
+}
+
+variable "domain_name" {
+  description = "Domain name to associate with the Amplify app"
+  type        = string
+}
+
+variable "main_branch_name" {
+  description = "Name of the main branch to deploy"
+  type        = string
+  default     = "main"
+}
+
+variable "hugo_version" {
+  description = "Hugo version to use for building the site"
+  type        = string
+  default     = "0.147.8"
+}
+
+variable "enable_www_subdomain" {
+  description = "Whether to enable www subdomain redirect"
+  type        = bool
+  default     = true
+}
+
+variable "environment_variables" {
+  description = "Environment variables for the Amplify app"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "auto_branch_creation_patterns" {
+  description = "Patterns for auto branch creation in Amplify app"
+  type        = list(string)
+  default = [
+    "*",
+    "*/**",
+  ]
+}


### PR DESCRIPTION
This pull request introduces significant changes to integrate AWS Amplify into the Terraform setup for the `jentz.co` project. It includes the creation of a new module for managing Amplify resources, updates to the main Terraform configuration, and enhancements to the project's infrastructure. The most important changes are grouped into themes below.

### Amplify Module Creation:
* Added new Terraform module `amplify` for managing AWS Amplify resources, including `aws_amplify_app`, `aws_amplify_branch`, and `aws_amplify_domain_association`. This module supports Hugo-based builds, automatic branch creation, and domain associations. (`terraform/modules/amplify/main.tf`, [terraform/modules/amplify/main.tfR1-R69](diffhunk://#diff-bcf46ab9cda42799baa8ab14438627923c0af5bb2ee3b196056f61c6be6b4156R1-R69))
* Defined variables for the Amplify module, such as `app_name`, `repository_url`, `domain_name`, `hugo_version`, and `environment_variables`. (`terraform/modules/amplify/variables.tf`, [terraform/modules/amplify/variables.tfR1-R59](diffhunk://#diff-153537d99e9e542b9cb1e35649f692010740127958a152cb538cb74a84917f6eR1-R59))
* Added outputs for the Amplify module, including `app_id`, `app_default_domain`, and `domain_association_id`. (`terraform/modules/amplify/outputs.tf`, [terraform/modules/amplify/outputs.tfR1-R24](diffhunk://#diff-74ef911f5479a4fe6a2706eb629e952f93b5019a345cc13e098b37b9cc39ea30R1-R24))

### Integration with `jentz.co` Terraform Configuration:
* Integrated the Amplify module into the main Terraform configuration by defining the `module "jentz_co_amplify"` block with required inputs such as `app_name`, `repository_url`, and `domain_name`. (`terraform/jentz.co/main.tf`, [terraform/jentz.co/main.tfR5-R28](diffhunk://#diff-ac5c518f2d0e35a6bc821a95e077236428e14fa2c6debfb247740f4a312dc91dR5-R28))
* Added outputs in the `jentz.co` configuration to expose Amplify-related details, such as `amplify_app_id` and `amplify_default_domain`. (`terraform/jentz.co/outputs.tf`, [terraform/jentz.co/outputs.tfR1-R14](diffhunk://#diff-bc5739ff3b3d9ba7d84d178826f0e474be92e0bd091085af4ad15029aa82bb3eR1-R14))

### Infrastructure Enhancements:
* Enabled encryption for the Terraform backend S3 bucket to enhance security. (`terraform/jentz.co/providers.tf`, [terraform/jentz.co/providers.tfR19](diffhunk://#diff-2ac085aa40679fc73303dd1796763d6e5f002d611b0dace91054642356eaf673R19))
* Added a new variable `github_access_token` to securely pass GitHub access tokens for repository integration. (`terraform/jentz.co/variables.tf`, [terraform/jentz.co/variables.tfR1-R5](diffhunk://#diff-2d551ee11520b7c4f9c76aad7c6e3d06b6ee616f75addb86ac9d50101c3ff6feR1-R5))

### Provider and Version Updates:
* Introduced a `.terraform.lock.hcl` file in the Amplify module to lock the AWS provider version at `~> 5.0`. (`terraform/modules/amplify/.terraform.lock.hcl`, [terraform/modules/amplify/.terraform.lock.hclR1-R25](diffhunk://#diff-edc5f04dc4f22aacee9d89c82e61467254af0dd99ec3faa1ddcc59983bd5e642R1-R25))
* Specified required Terraform and AWS provider versions for the Amplify module. (`terraform/modules/amplify/providers.tf`, [terraform/modules/amplify/providers.tfR1-R9](diffhunk://#diff-2caf02fb877b0a6d8a1c830f7a62195184a8094afb63c90bdd55e57678bda010R1-R9))