### PR TITLE
feat: add initial Terraform configuration for Cognito

### DIFF
--- a/terraform/cognito-sandbox/.terraform.lock.hcl
+++ b/terraform/cognito-sandbox/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/cognito-sandbox/main.tf
+++ b/terraform/cognito-sandbox/main.tf
@@ -2,22 +2,11 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-import {
-  to = aws_cognito_user_pool_domain.main
-  id = "eu-west-1r7zfnvwv0"
-}
-
 resource "aws_cognito_user_pool_domain" "main" {
   certificate_arn       = null
   domain                = "eu-west-1r7zfnvwv0"
   managed_login_version = 2
   user_pool_id          = aws_cognito_user_pool.pool.id
-}
-
-#
-import {
-  to = aws_cognito_user_pool.pool
-  id = "eu-west-1_R7Zfnvwv0"
 }
 
 resource "aws_cognito_user_pool" "pool" {
@@ -104,16 +93,6 @@ resource "aws_cognito_user_pool" "pool" {
     sms_message           = null
   }
 
-}
-
-import {
-  to = aws_cognito_user_pool_client.public_client
-  id = "eu-west-1_R7Zfnvwv0/2uc1bc2vfstfp198uvq8shsepa"
-}
-
-import {
-  to = aws_cognito_user_pool_client.confidential_client
-  id = "eu-west-1_R7Zfnvwv0/39askr3efqggd2djrimgijpbcr"
 }
 
 resource "aws_cognito_user_pool_client" "public_client" {

--- a/terraform/cognito-sandbox/main.tf
+++ b/terraform/cognito-sandbox/main.tf
@@ -21,12 +21,12 @@ import {
 }
 
 resource "aws_cognito_user_pool" "pool" {
-  alias_attributes           = ["email"]
-  auto_verified_attributes   = ["email"]
-  deletion_protection        = "ACTIVE"
-  mfa_configuration          = "OFF"
-  name                       = "User pool - d3t5g8"
-  user_pool_tier             = "ESSENTIALS"
+  alias_attributes         = ["email"]
+  auto_verified_attributes = ["email"]
+  deletion_protection      = "ACTIVE"
+  mfa_configuration        = "OFF"
+  name                     = "User pool - d3t5g8"
+  user_pool_tier           = "ESSENTIALS"
   account_recovery_setting {
     recovery_mechanism {
       name     = "verified_email"
@@ -63,8 +63,8 @@ resource "aws_cognito_user_pool" "pool" {
     name                     = "email"
     required                 = true
     string_attribute_constraints {
-      max_length = jsonencode(2048)
-      min_length = jsonencode(0)
+      max_length = 2048
+      min_length = 0
     }
   }
   schema {
@@ -74,8 +74,8 @@ resource "aws_cognito_user_pool" "pool" {
     name                     = "family_name"
     required                 = true
     string_attribute_constraints {
-      max_length = jsonencode(2048)
-      min_length = jsonencode(0)
+      max_length = 2048
+      min_length = 0
     }
   }
   schema {
@@ -85,8 +85,8 @@ resource "aws_cognito_user_pool" "pool" {
     name                     = "given_name"
     required                 = true
     string_attribute_constraints {
-      max_length = jsonencode(2048)
-      min_length = jsonencode(0)
+      max_length = 2048
+      min_length = 0
     }
   }
   sign_in_policy {
@@ -103,7 +103,7 @@ resource "aws_cognito_user_pool" "pool" {
     email_subject_by_link = null
     sms_message           = null
   }
-  
+
 }
 
 import {
@@ -171,5 +171,3 @@ resource "aws_cognito_user_pool_client" "confidential_client" {
     refresh_token = "days"
   }
 }
-
-

--- a/terraform/cognito-sandbox/main.tf
+++ b/terraform/cognito-sandbox/main.tf
@@ -1,0 +1,175 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+import {
+  to = aws_cognito_user_pool_domain.main
+  id = "eu-west-1r7zfnvwv0"
+}
+
+resource "aws_cognito_user_pool_domain" "main" {
+  certificate_arn       = null
+  domain                = "eu-west-1r7zfnvwv0"
+  managed_login_version = 2
+  user_pool_id          = aws_cognito_user_pool.pool.id
+}
+
+#
+import {
+  to = aws_cognito_user_pool.pool
+  id = "eu-west-1_R7Zfnvwv0"
+}
+
+resource "aws_cognito_user_pool" "pool" {
+  alias_attributes           = ["email"]
+  auto_verified_attributes   = ["email"]
+  deletion_protection        = "ACTIVE"
+  mfa_configuration          = "OFF"
+  name                       = "User pool - d3t5g8"
+  user_pool_tier             = "ESSENTIALS"
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+    recovery_mechanism {
+      name     = "verified_phone_number"
+      priority = 2
+    }
+  }
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+  }
+  email_configuration {
+    configuration_set      = null
+    email_sending_account  = "COGNITO_DEFAULT"
+    from_email_address     = null
+    reply_to_email_address = null
+    source_arn             = null
+  }
+  password_policy {
+    minimum_length                   = 8
+    password_history_size            = 0
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "email"
+    required                 = true
+    string_attribute_constraints {
+      max_length = jsonencode(2048)
+      min_length = jsonencode(0)
+    }
+  }
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "family_name"
+    required                 = true
+    string_attribute_constraints {
+      max_length = jsonencode(2048)
+      min_length = jsonencode(0)
+    }
+  }
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "given_name"
+    required                 = true
+    string_attribute_constraints {
+      max_length = jsonencode(2048)
+      min_length = jsonencode(0)
+    }
+  }
+  sign_in_policy {
+    allowed_first_auth_factors = ["PASSWORD"]
+  }
+  username_configuration {
+    case_sensitive = false
+  }
+  verification_message_template {
+    default_email_option  = "CONFIRM_WITH_CODE"
+    email_message         = null
+    email_message_by_link = null
+    email_subject         = null
+    email_subject_by_link = null
+    sms_message           = null
+  }
+  
+}
+
+import {
+  to = aws_cognito_user_pool_client.public_client
+  id = "eu-west-1_R7Zfnvwv0/2uc1bc2vfstfp198uvq8shsepa"
+}
+
+import {
+  to = aws_cognito_user_pool_client.confidential_client
+  id = "eu-west-1_R7Zfnvwv0/39askr3efqggd2djrimgijpbcr"
+}
+
+resource "aws_cognito_user_pool_client" "public_client" {
+  access_token_validity                         = 60
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = true
+  allowed_oauth_scopes                          = ["email", "openid", "phone"]
+  auth_session_validity                         = 3
+  callback_urls                                 = ["http://localhost:9555/callback", "https://d84l1y8p4kdic.cloudfront.net"]
+  default_redirect_uri                          = null
+  enable_propagate_additional_user_context_data = false
+  enable_token_revocation                       = true
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_AUTH", "ALLOW_USER_SRP_AUTH"]
+  generate_secret                               = null
+  id_token_validity                             = 60
+  logout_urls                                   = []
+  name                                          = "My SPA app - ghz1nk"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = []
+  refresh_token_validity                        = 5
+  supported_identity_providers                  = ["COGNITO"]
+  user_pool_id                                  = aws_cognito_user_pool.pool.id
+  write_attributes                              = []
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+}
+
+resource "aws_cognito_user_pool_client" "confidential_client" {
+  access_token_validity                         = 60
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = true
+  allowed_oauth_scopes                          = ["email", "openid", "phone", "profile"]
+  auth_session_validity                         = 3
+  callback_urls                                 = ["http://localhost:9555/callback", "https://d84l1y8p4kdic.cloudfront.net"]
+  default_redirect_uri                          = null
+  enable_propagate_additional_user_context_data = false
+  enable_token_revocation                       = true
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_AUTH", "ALLOW_USER_SRP_AUTH"]
+  generate_secret                               = null
+  id_token_validity                             = 60
+  logout_urls                                   = []
+  name                                          = "confidential auth code client"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = []
+  refresh_token_validity                        = 5
+  supported_identity_providers                  = ["COGNITO"]
+  user_pool_id                                  = aws_cognito_user_pool.pool.id
+  write_attributes                              = []
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+}
+
+

--- a/terraform/cognito-sandbox/providers.tf
+++ b/terraform/cognito-sandbox/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "terraform-state-867e5926"
+    key            = "cognito-sandbox/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
This pull request introduces Terraform configurations to set up and manage AWS Cognito resources in a sandbox environment. The changes include defining providers, configuring backend storage, and creating resources for a user pool, user pool domain, and user pool clients.

### Provider and Backend Configuration:
* [`terraform/cognito-sandbox/providers.tf`](diffhunk://#diff-0f8917f5735b2386b3e3c1131073e7520ab7d700885ed8509d1a50d47509cd26R1-R17): Specifies the required Terraform version (`>= 1.9`) and the AWS provider version (`~> 5.0`). Configures an S3 backend for storing Terraform state with encryption and DynamoDB for state locking.

### AWS Cognito Resources:
* [`terraform/cognito-sandbox/main.tf`](diffhunk://#diff-9b4a89f6b77b4d8fea50c7665abb69b22cb9dc39da21b4ce6b56d7ef0df0c370R1-R175): Adds resources for a Cognito user pool (`aws_cognito_user_pool.pool`), user pool domain (`aws_cognito_user_pool_domain.main`), and two user pool clients (`aws_cognito_user_pool_client.public_client` and `aws_cognito_user_pool_client.confidential_client`). These resources define attributes such as MFA configuration, password policies, OAuth flows, and token validity settings.

### Dependency Lock File:
* [`terraform/cognito-sandbox/.terraform.lock.hcl`](diffhunk://#diff-72077edb64cb365f157d973dc3accb1322112d1ab4256c0330e43052ad41f207R1-R25): Adds a lock file to ensure consistent provider versions across environments, specifying the AWS provider version (`5.100.0`) and its hash values.