### PR TITLE
feat: add dependabot config and sha-pin actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: refactor
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: terraform
+    directories:
+      - /terraform/bootstrap
+      - /terraform/cognito-sandbox
+      - /terraform/common
+      - /terraform/jentz.co
+      - /terraform/modules/amplify
+      - /terraform/modules/s3
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: refactor
+      include: scope
+    groups:
+      aws-provider:
+        patterns:
+          - "hashicorp/aws"
+      other-providers:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "hashicorp/aws"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::567516037984:role/github-actions-role
           aws-region: eu-west-1
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.14.9
 


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for `github-actions` (root) and `terraform` across all six project/module directories. Weekly Monday cadence; AWS provider updates grouped separately from other providers to keep PR noise down.
- SHA-pin every action in `terraform.yml` (`actions/checkout`, `aws-actions/configure-aws-credentials`, `hashicorp/setup-terraform`) with trailing version comments so Dependabot can keep them current. Closes the tag-rewrite supply-chain hole.

## Test plan
- [ ] Workflow run on this PR completes successfully (proves SHA-pinned actions still resolve and behave the same)
- [ ] After merge, *Insights → Dependency graph → Dependabot* lists both ecosystems and shows the six Terraform directories
- [ ] Trigger a manual "Check for updates" in Dependabot and confirm at least one ecosystem reports zero or sane proposed updates