### PR TITLE
feat: add ci plan and deploy IAM roles

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -62,26 +62,30 @@ resource "aws_iam_role_policy_attachment" "github_actions_admin" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
+data "aws_iam_policy_document" "github_actions_plan_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:jentz/aws-infrastructure:environment:plan"]
+    }
+  }
+}
+
 resource "aws_iam_role" "github_actions_plan" {
-  name = "github-actions-plan-role"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = "repo:jentz/aws-infrastructure:environment:plan"
-          }
-        }
-      }
-    ]
-  })
+  name               = "github-actions-plan-role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_plan_assume.json
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_plan_readonly" {
@@ -89,46 +93,35 @@ resource "aws_iam_role_policy_attachment" "github_actions_plan_readonly" {
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
-resource "aws_iam_role_policy" "github_actions_plan_state_read" {
-  name = "tf-state-read"
-  role = aws_iam_role.github_actions_plan.id
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["s3:ListBucket"]
-        Resource = module.terraform_state_s3.bucket_arn
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject"]
-        Resource = "${module.terraform_state_s3.bucket_arn}/*"
-      }
-    ]
-  })
+data "aws_iam_policy_document" "github_actions_deploy_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:jentz/aws-infrastructure:environment:deploy"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:ref"
+      values   = ["refs/heads/main"]
+    }
+  }
 }
 
 resource "aws_iam_role" "github_actions_deploy" {
-  name = "github-actions-deploy-role"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = "repo:jentz/aws-infrastructure:environment:deploy"
-          }
-        }
-      }
-    ]
-  })
+  name               = "github-actions-deploy-role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_deploy_assume.json
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_deploy_admin" {

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -61,3 +61,77 @@ resource "aws_iam_role_policy_attachment" "github_actions_admin" {
   role       = aws_iam_role.github_actions.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+
+resource "aws_iam_role" "github_actions_plan" {
+  name = "github-actions-plan-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:jentz/aws-infrastructure:environment:plan"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_plan_readonly" {
+  role       = aws_iam_role.github_actions_plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy" "github_actions_plan_state_read" {
+  name = "tf-state-read"
+  role = aws_iam_role.github_actions_plan.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.terraform_state_s3.bucket_arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "${module.terraform_state_s3.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "github_actions_deploy" {
+  name = "github-actions-deploy-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:jentz/aws-infrastructure:environment:deploy"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_deploy_admin" {
+  role       = aws_iam_role.github_actions_deploy.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}


### PR DESCRIPTION
## Summary

First of three PRs that split the single `github-actions-role` admin role into a read-only plan role and an admin deploy role, enabling a GitHub Environments approval gate before apply.

This PR adds the new roles only — workflow stays unchanged so it applies via the existing admin role. PR B will switch the workflow to consume these via `plan` and `deploy` GitHub Environments. PR C will remove the old role.

- `github-actions-plan-role`: trust scoped to `environment:plan`, AWS `ReadOnlyAccess` plus inline `s3:Get/ListBucket` on the terraform-state bucket.
- `github-actions-deploy-role`: trust scoped to `environment:deploy`, AWS `AdministratorAccess`. Approval gate is enforced by the `deploy` environment in PR B (required reviewers + branch policy = `main`).

## Test plan

- [x] Workflow runs `terraform plan` on this PR (should be `+5` resources in bootstrap)
- [ ] After merge, workflow's apply on `main` succeeds via the existing admin role
- [ ] `aws iam get-role --role-name github-actions-plan-role` returns the role with the expected trust policy
- [ ] `aws iam get-role --role-name github-actions-deploy-role` returns the role with the expected trust policy
- [ ] Before opening PR B, create the `plan` and `deploy` environments in repo Settings → Environments per the cutover plan