### PR TITLE
refactor: remove unused github_access_token variable

### DIFF
--- a/terraform/jentz.co/main.tf
+++ b/terraform/jentz.co/main.tf
@@ -8,8 +8,6 @@ module "jentz_co_amplify" {
   app_name       = "jentz-co"
   repository_url = "https://github.com/jentz/jentz.co"
 
-  github_access_token = var.github_access_token
-
   domain_name          = "jentz.co"
   enable_www_subdomain = true
   main_branch_name     = "main" # Change this if your main branch has a different name

--- a/terraform/jentz.co/variables.tf
+++ b/terraform/jentz.co/variables.tf
@@ -1,6 +1,0 @@
-variable "github_access_token" {
-  description = "GitHub personal access token for repository access, only used for bootstrapping the Amplify app, should be removed after."
-  default     = ""
-  type        = string
-  sensitive   = true
-}

--- a/terraform/modules/amplify/main.tf
+++ b/terraform/modules/amplify/main.tf
@@ -2,10 +2,6 @@ resource "aws_amplify_app" "this" {
   name       = var.app_name
   repository = var.repository_url
 
-  # Only include access_token when github_access_token is set
-  access_token = try(length(var.github_access_token) > 0 ? var.github_access_token : tostring({}), null)
-
-
   # Hugo build settings
   build_spec = <<-EOT
     version: 1

--- a/terraform/modules/amplify/variables.tf
+++ b/terraform/modules/amplify/variables.tf
@@ -8,12 +8,6 @@ variable "repository_url" {
   type        = string
 }
 
-variable "github_access_token" {
-  description = "GitHub personal access token for repository access"
-  type        = string
-  sensitive   = true
-}
-
 variable "domain_name" {
   description = "Domain name to associate with the Amplify app"
   type        = string


### PR DESCRIPTION
## Summary

The variable was wired through \`terraform/jentz.co/\` into \`terraform/modules/amplify/\` to seed \`aws_amplify_app.access_token\` at first apply. The Amplify app is long since bootstrapped, AWS retains the stored token across applies (write-once attribute), and the variable currently defaults to \`""\` so the module already passes \`null\` via the \`try(...)\` fallback. Removing the dead plumbing.

- \`terraform/jentz.co/main.tf\`: drop the \`github_access_token = var.github_access_token\` module input.
- \`terraform/jentz.co/variables.tf\`: deleted (was the only variable).
- \`terraform/modules/amplify/main.tf\`: drop \`access_token = try(...)\` and its comment.
- \`terraform/modules/amplify/variables.tf\`: drop the variable block.

## Test plan

- [x] PR's plan job shows \`No changes\` for \`terraform/jentz.co\` (no destroy/replace, no in-place update on \`aws_amplify_app.this\`)
- [x] After merge, apply on main shows \`No changes\` and the Amplify app continues to build from GitHub on the next push to \`jentz/jentz.co\`