### PR TITLE
refactor: remove legacy github-actions admin role

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -33,35 +33,6 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
-resource "aws_iam_role" "github_actions" {
-  name = "github-actions-role"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:jentz/aws-infrastructure:*"
-          }
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "github_actions_admin" {
-  role       = aws_iam_role.github_actions.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
 data "aws_iam_policy_document" "github_actions_plan_assume" {
   statement {
     effect  = "Allow"


### PR DESCRIPTION
## Summary

PR C of the plan/deploy cutover. Removes the original \`github-actions-role\` (admin, wildcard \`sub\` trust) from \`terraform/bootstrap/main.tf\` now that #15 added the read-only plan role + admin deploy role and #17 cut the workflow over to them. The OIDC provider stays — both new roles depend on it.

This PR is also the first end-to-end test of the new pipeline:

1. Plan job runs against the \`plan\` environment using \`github-actions-plan-role\`. Sticky comment should appear with the destroy diff for \`terraform/bootstrap\`.
2. After merge, the \`apply\` job sits in \"Waiting\" with the deploy environment's required-reviewer prompt.
3. Approval triggers \`apply plan.out\` against \`github-actions-deploy-role\`, which deletes the old role.

## Test plan

- [ ] Plan shows \`Plan: 0 to add, 0 to change, 2 to destroy.\` (role + attachment)
- [ ] Sticky PR comment appears with the bootstrap section showing the destroy
- [ ] After merge, the \`apply\` job pauses for review under the \`deploy\` environment
- [ ] Approving applies the plan and deletes \`github-actions-role\`
- [ ] \`aws iam get-role --role-name github-actions-role\` returns \`NoSuchEntity\` afterwards