### PR TITLE
feat: surface plan in run summary before apply approval

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -95,27 +95,42 @@ jobs:
               .filter(d => d.startsWith('plan-'))
               .sort();
 
+            const renderSection = (projectDir, text) =>
+              `<details><summary>terraform/${projectDir}</summary>\n\n\`\`\`hcl\n${text}\n\`\`\`\n\n</details>`;
+
             const sections = dirs.map(d => {
               const projectDir = d.replace(/^plan-/, '');
               const planPath = path.join('plans', d, 'plan.txt');
-              let text = fs.existsSync(planPath) ? fs.readFileSync(planPath, 'utf8') : '(plan.txt missing)';
-              let footer = '';
-              if (text.length > PER_DIR_CAP) {
-                text = text.slice(0, PER_DIR_CAP);
-                footer = '\n\n... (truncated; see Actions log for full plan)';
-              }
-              return `<details><summary>terraform/${projectDir}</summary>\n\n\`\`\`hcl\n${text}${footer}\n\`\`\`\n\n</details>`;
+              const text = fs.existsSync(planPath) ? fs.readFileSync(planPath, 'utf8') : '(plan.txt missing)';
+              const capped = text.length > PER_DIR_CAP
+                ? text.slice(0, PER_DIR_CAP) + '\n\n... (truncated; see Actions log for full plan)'
+                : text;
+              return {
+                full: renderSection(projectDir, text),
+                capped: renderSection(projectDir, capped),
+              };
             });
 
-            const body = `${marker}\n## Terraform plan\n\n${sections.join('\n')}`;
+            const header = `${marker}\n## Terraform plan\n\n`;
 
-            await core.summary.addRaw(body).write();
+            await core.summary.addRaw(header + sections.map(s => s.full).join('\n')).write();
 
             if (context.eventName !== 'pull_request') return;
 
-            const comment = body.length > TOTAL_CAP
-              ? body.slice(0, TOTAL_CAP) + '\n\n_(truncated; see Actions run for details)_'
-              : body;
+            const truncationNotice = '\n\n_(truncated; see Actions run for details)_';
+            const cappedBody = header + sections.map(s => s.capped).join('\n');
+            let comment = cappedBody;
+            if (cappedBody.length > TOTAL_CAP) {
+              const accepted = [];
+              let used = header.length + truncationNotice.length;
+              for (const s of sections) {
+                const cost = (accepted.length ? 1 : 0) + s.capped.length;
+                if (used + cost > TOTAL_CAP) break;
+                used += cost;
+                accepted.push(s.capped);
+              }
+              comment = header + accepted.join('\n') + truncationNotice;
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -69,9 +69,8 @@ jobs:
             terraform/${{ matrix.dir }}/plan.txt
           retention-days: 5
 
-  comment:
-    name: Comment plan on PR
-    if: github.event_name == 'pull_request'
+  summary:
+    name: Plan summary
     needs: plan
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +80,7 @@ jobs:
           pattern: plan-*
           path: plans
 
-      - name: Post sticky plan comment
+      - name: Write run summary and sticky PR comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -108,10 +107,15 @@ jobs:
               return `<details><summary>terraform/${projectDir}</summary>\n\n\`\`\`hcl\n${text}${footer}\n\`\`\`\n\n</details>`;
             });
 
-            let body = `${marker}\n## Terraform plan\n\n${sections.join('\n')}`;
-            if (body.length > TOTAL_CAP) {
-              body = body.slice(0, TOTAL_CAP) + '\n\n_(comment truncated; see Actions run for details)_';
-            }
+            const body = `${marker}\n## Terraform plan\n\n${sections.join('\n')}`;
+
+            await core.summary.addRaw(body).write();
+
+            if (context.eventName !== 'pull_request') return;
+
+            const comment = body.length > TOTAL_CAP
+              ? body.slice(0, TOTAL_CAP) + '\n\n_(truncated; see Actions run for details)_'
+              : body;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -125,21 +129,21 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body,
+                body: comment,
               });
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
+                body: comment,
               });
             }
 
   apply:
     name: Apply
     if: github.event_name == 'push'
-    needs: plan
+    needs: [plan, summary]
     runs-on: ubuntu-latest
     environment: deploy
     steps:


### PR DESCRIPTION
## Summary

The \`deploy\` environment's approval prompt currently opens before the plan is visible anywhere on the run page. Reviewers had to drill three clicks into the plan job logs to see what they were approving (you flagged this on the PR 18 merge run).

This PR makes the rendered plan visible on the run page itself:

- Rename the \`comment\` job to \`summary\`. It now runs on both PR and push (the job-level \`if: pull_request\` is gone).
- The github-script writes the rendered plan to the run summary via \`core.summary.addRaw(body).write()\` on every event.
- The sticky PR comment still only fires on \`pull_request\` (early-return after the summary write).
- \`apply.needs\` is extended to \`[plan, summary]\` so the deploy approval prompt doesn't open until the summary has landed.
- The 60k-char cap is now scoped to the PR comment branch only (it exists for GitHub's 65535 issue-comment limit). The run summary, which allows ~1 MiB, gets the full untruncated body.

## Test plan

- [x] Plan job is green on this PR for all four dirs
- [ ] PR's run page shows a "Summary" section at the top with the rendered plan
- [ ] Sticky PR comment is also posted as before
- [ ] After merge, the post-merge run shows the plan summary on the run page **before** the deploy approval prompt opens (the apply job will say "Waiting" while showing the summary above)