### PR TITLE
refactor: scope plan role trust by event, not environment

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -49,7 +49,10 @@ data "aws_iam_policy_document" "github_actions_plan_assume" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:jentz/aws-infrastructure:environment:plan"]
+      values = [
+        "repo:jentz/aws-infrastructure:pull_request",
+        "repo:jentz/aws-infrastructure:ref:refs/heads/main",
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace the plan role's OIDC trust `StringEquals` on `sub = repo:.../environment:plan` with an explicit two-element list: `pull_request` and `ref:refs/heads/main` — the only subjects this workflow ever produces.
- This is **PR 1 of 2**. PR 2 will drop the now-pointless `environment: plan` declaration from the workflow, which eliminates the "plan inactive" deployment clutter that fills the GitHub Environments UI after every apply.

## Why

The `plan` GitHub Environment serves no protective purpose — there are no approval rules on it, and the IAM role is read-only. But every plan job (matrix x4) creates a "plan" deployment, which gets marked **inactive** as soon as `deploy` activates. Switching the trust to scope by event/branch lets the workflow drop the environment declaration without losing security.

The deploy role's tight scoping (`environment:deploy + ref:refs/heads/main` + admin) is **unchanged**.

## Rollout — IMPORTANT

Do **not** open the workflow-cleanup PR until this PR's `Apply` check is green on `main`. Until then, the plan job still uses `environment: plan` (matches old trust on main), so this PR's own checks pass against the currently-applied trust.

After this PR's apply lands, the new trust accepts only `pull_request` and `ref:refs/heads/main`. Any subsequent run with `environment: plan` still in the workflow will fail OIDC — which is why PR 2 should follow promptly.

## Test plan

- [x] PR check `Plan bootstrap` passes (proves old trust still in effect during this PR's runs)
- [x] After merge, `Apply` check on main succeeds
- [x] `aws iam get-role --role-name github-actions-plan-role` shows the trust policy lists both `pull_request` and `ref:refs/heads/main` and no longer references `environment:plan`
- [x] Open PR 2 (workflow cleanup) only after the apply above is green