### PR TITLE
refactor: drop plan environment, add run-name

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,10 @@
 name: Terraform
 
+run-name: >-
+  ${{ github.event_name == 'pull_request'
+      && format('Plan for PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
+      || format('Apply on main: {0}', github.event.head_commit.message) }}
+
 on:
   pull_request:
     paths:
@@ -28,7 +33,6 @@ jobs:
   plan:
     name: Plan ${{ matrix.dir }}
     runs-on: ubuntu-latest
-    environment: plan
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,7 +3,9 @@ name: Terraform
 run-name: >-
   ${{ github.event_name == 'pull_request'
       && format('Plan for PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
-      || format('Apply on main: {0}', github.event.head_commit.message) }}
+      || github.event_name == 'push'
+      && format('Apply on main: {0}', github.event.head_commit.message)
+      || format('Manual plan on {0}', github.ref_name) }}
 
 on:
   pull_request:
@@ -14,6 +16,7 @@ on:
       - main
     paths:
       - 'terraform/**'
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

- Remove `environment: plan` from the matrix plan job. With PR #21 merged, the plan role's OIDC trust now accepts `pull_request` and `ref:refs/heads/main` subjects directly — the GitHub Environment is no longer needed.
- Add a top-level `run-name` so the Actions list shows useful titles (`Plan for PR #N: <title>` / `Apply on main: <message>`) instead of just commit messages.

## Why

The `plan` environment had no protection rules and the role was already read-only via IAM, so it was decorative — but every matrix entry created a "plan" deployment that got marked **inactive** after each apply. The Environments sidebar filled with stale "plan inactive" entries on every merge.

After this lands, only the legitimate `deploy` environment shows up in the Environments UI.

## Test plan

- [ ] PR check `Plan bootstrap`/`cognito-sandbox`/`common`/`jentz.co` succeed without `environment: plan` declared (proves the new trust policy from PR #21 is correct)
- [ ] Run title in the Actions list reads `Plan for PR #N: <title>` for this PR
- [ ] PR run page shows **no** "plan" deployments in the right sidebar
- [ ] Sticky PR comment with the rendered terraform plan still posts
- [ ] After merge: `Apply` runs gated by the `deploy` environment as before; run title reads `Apply on main: <commit message>`
- [ ] Environments sidebar shows only the new `deploy` deployment — no fresh `plan` deployment created or marked inactive

## Manual cleanup (after this lands)

In **Settings -> Environments**, delete the now-orphaned `plan` environment to clear the historical "plan inactive" deployments from the sidebar. Not part of this PR.