### PR TITLE
refactor: improve Makefile for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,44 @@
-# Makefile for Terraform formatting and linting
-
-.SHELLFLAGS := -e -c
+.SHELLFLAGS := -eu -o pipefail -c
 
 TERRAFORM_DIRS := $(shell find terraform -type d \( -name .terraform \) -prune -o -type d -print)
-TERRAFORM_PROJ_DIRS := $(shell find terraform -maxdepth 1 -mindepth 1 -type d ! -name modules ! -name .terraform)
+PROJ_DIRS      := $(shell find terraform -maxdepth 1 -mindepth 1 -type d ! -name modules ! -name .terraform)
 
-.PHONY: fmt lint init plan apply all
+PARALLEL := 4
 
-all: fmt lint
+.DEFAULT_GOAL := help
+.PHONY: help fmt check lint init plan apply clean
 
-fmt:
-	@echo "Formatting Terraform files..."
-	@terraform fmt -recursive 
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  %-10s %s\n", $$1, $$2}'
 
-lint:
-	@echo "Linting Terraform files..."
-	@for dir in $(TERRAFORM_DIRS); do \
-		echo "Validating Terraform in $$dir..."; \
-		terraform -chdir=$$dir init -backend=false -input=false >/dev/null; \
-		terraform -chdir=$$dir validate; \
+fmt: ## Format all Terraform files
+	@terraform fmt -recursive terraform
+
+check: ## Check formatting without modifying (CI-safe)
+	@terraform fmt -check -recursive terraform
+
+lint: ## Validate all Terraform directories (parallel)
+	@printf '%s\n' $(TERRAFORM_DIRS) | \
+		xargs -P$(PARALLEL) -I{} sh -c \
+		'echo "→ {}"; terraform -chdir={} init -backend=false -input=false >/dev/null && terraform -chdir={} validate'
+
+init: ## Initialize all project directories (parallel)
+	@printf '%s\n' $(PROJ_DIRS) | \
+		xargs -P$(PARALLEL) -I{} sh -c \
+		'echo "→ {}"; terraform -chdir={} init -input=false'
+
+plan: ## Plan all project directories
+	@for dir in $(PROJ_DIRS); do \
+		echo "→ $$dir"; \
+		terraform -chdir=$$dir plan -input=false; \
 	done
 
-init:
-	@echo "Initializing Terraform directories..."
-	@for dir in $(TERRAFORM_DIRS); do \
-		echo "Initializing Terraform in $$dir..."; \
-		terraform -chdir=$$dir init; \
+apply: ## Apply all project directories
+	@for dir in $(PROJ_DIRS); do \
+		echo "→ $$dir"; \
+		terraform -chdir=$$dir apply -input=false; \
 	done
 
-plan:
-	@echo "Planning Terraform changes..."
-	@for dir in $(TERRAFORM_PROJ_DIRS); do \
-		echo "Planning Terraform in $$dir..."; \
-		terraform -chdir=$$dir plan; \
-	done
-
-apply:
-	@echo "Applying Terraform changes..."
-	@for dir in $(TERRAFORM_PROJ_DIRS); do \
-		echo "Applying Terraform in $$dir..."; \
-		terraform -chdir=$$dir apply -auto-approve; \
-	done
+clean: ## Remove .terraform directories
+	@find terraform -name '.terraform' -type d -exec rm -rf {} +


### PR DESCRIPTION
Add help as default target, parallelise lint and init via xargs -P4, add check and clean targets, tighten shell flags, and remove -auto-approve from apply.